### PR TITLE
[#23] Slice 타입명 생성 시 대문자 약어 복수화 버그 수정

### DIFF
--- a/internal/naming/naming.go
+++ b/internal/naming/naming.go
@@ -1,0 +1,46 @@
+package naming
+
+// commonInitialisms is the set of known initialisms, mirroring golint's list.
+//
+// gorm's pluralization (via github.com/jinzhu/inflection) appends an uppercase
+// "S" to an all-caps trailing initialism, so "ProductURL" becomes "ProductURLS"
+// and "UserID" becomes "UserIDS". That is not idiomatic Go. FixInitialismPlural
+// rewrites the trailing "S" to a lowercase "s" for these known initialisms.
+var commonInitialisms = map[string]bool{
+	"ACL": true, "API": true, "ASCII": true, "CPU": true, "CSS": true,
+	"DNS": true, "EOF": true, "GUID": true, "HTML": true, "HTTP": true,
+	"HTTPS": true, "ID": true, "IP": true, "JSON": true, "LHS": true,
+	"QPS": true, "RAM": true, "RHS": true, "RPC": true, "SLA": true,
+	"SMTP": true, "SQL": true, "SSH": true, "TCP": true, "TLS": true,
+	"TTL": true, "UDP": true, "UI": true, "UID": true, "UUID": true,
+	"URI": true, "URL": true, "UTF8": true, "VM": true, "XML": true,
+	"XMPP": true, "XSRF": true, "XSS": true,
+}
+
+// FixInitialismPlural lowercases a trailing plural "S" that gorm/inflection has
+// appended to an all-caps initialism, turning "ProductURLS" into "ProductURLs"
+// and "UserIDS" into "UserIDs".
+//
+// It only rewrites when the trailing uppercase run (minus the final "S") is a
+// known initialism, so names that pluralize normally are left untouched:
+// "Orders" and "Clothes" end in a lowercase "s", and standalone acronyms like
+// "CMS" are not in the list ("CM" is not an initialism).
+func FixInitialismPlural(name string) string {
+	if len(name) < 2 || name[len(name)-1] != 'S' {
+		return name
+	}
+
+	body := name[:len(name)-1] // drop the trailing plural "S"
+
+	// Walk back over the trailing run of uppercase ASCII letters.
+	i := len(body)
+	for i > 0 && body[i-1] >= 'A' && body[i-1] <= 'Z' {
+		i--
+	}
+
+	if commonInitialisms[body[i:]] {
+		return body + "s"
+	}
+
+	return name
+}

--- a/internal/naming/naming_test.go
+++ b/internal/naming/naming_test.go
@@ -1,0 +1,35 @@
+package naming
+
+import "testing"
+
+func TestFixInitialismPlural(t *testing.T) {
+	cases := map[string]string{
+		// gorm/inflection appends an uppercase "S" to trailing initialisms.
+		"ProductURLS": "ProductURLs",
+		"ImageURLS":   "ImageURLs",
+		"URLS":        "URLs",
+		"UserIDS":     "UserIDs",
+		"IDS":         "IDs",
+		"APIS":        "APIs",
+		"UUIDS":       "UUIDs",
+
+		// Normal plurals end in a lowercase "s" and must stay untouched.
+		"Orders":  "Orders",
+		"Clothes": "Clothes",
+		"People":  "People",
+
+		// Trailing run that is not a known initialism must stay untouched.
+		"CMS": "CMS", // "CM" is not an initialism
+		"AS":  "AS",  // "A" is not an initialism
+
+		// Degenerate inputs.
+		"S": "S",
+		"":  "",
+	}
+
+	for in, want := range cases {
+		if got := FixInitialismPlural(in); got != want {
+			t.Errorf("FixInitialismPlural(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/internal/steps/generate_runner.go
+++ b/internal/steps/generate_runner.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 
 	config "github.com/myyrakle/gormery/internal/config"
+	"github.com/myyrakle/gormery/internal/naming"
+	gormSchema "gorm.io/gorm/schema"
 )
 
 func GenerateRunner(configFile config.ConfigFile, targets ProecssFileContexts) {
@@ -97,6 +99,14 @@ func generateCodeForTarget(i int, target ProecssFileContext) string {
 		tableName = *target.entityParam
 	}
 
+	// slice 타입명은 structName만의 순수 함수라 generate-time에 확정한다.
+	// gorm 복수화가 대문자 약어 끝에 대문자 S를 붙이는 문제(URL -> URLS)를
+	// FixInitialismPlural로 교정한 뒤 러너엔 최종 문자열만 리터럴로 넘긴다.
+	sliceTypeName := naming.FixInitialismPlural(gormSchema.NamingStrategy{NoLowerCase: true}.TableName(structName))
+	if sliceTypeName == structName {
+		sliceTypeName += "List"
+	}
+
 	code := fmt.Sprintf(`
 	%s, err := gormSchema.ParseWithSpecialTableName(
 		&target.%s{},
@@ -106,9 +116,9 @@ func generateCodeForTarget(i int, target ProecssFileContext) string {
 	)
 
 	if err == nil {
-		createGormFile(%s, "%s", "%s", "%s")
+		createGormFile(%s, "%s", "%s", "%s", "%s")
 	}
-`, id, targetTypename, id, filename, structName, tableName)
+`, id, targetTypename, id, filename, structName, tableName, sliceTypeName)
 
 	return code
 }
@@ -119,7 +129,7 @@ func generateCreateGormFileFunction(configFile config.ConfigFile) string {
 	code += `var basedir = ` + `"` + configFile.Basedir + `"` + "\n"
 	code += `var outputSuffix = ` + `"` + configFile.OutputSuffix + `"` + "\n"
 
-	code += `func createGormFile(schema *gormSchema.Schema, filename string, structName string, tableName string) {` + "\n"
+	code += `func createGormFile(schema *gormSchema.Schema, filename string, structName string, tableName string, sliceTypeName string) {` + "\n"
 	code += "\t" + `gormFilePath := strings.Replace(filename, ".go", "", 1) + outputSuffix` + "\n"
 
 	code += "\t" + `code := ""` + "\n"
@@ -159,13 +169,8 @@ func generateCreateGormFileFunction(configFile config.ConfigFile) string {
 
 	// Slice 타입 구현
 	if configFile.Features.Contains(config.FeatureSlice) {
-		// named type 명명
-		code += "\t" + `sliceTypeName := gormSchema.NamingStrategy{ NoLowerCase: true }.TableName(structName)` + "\n"
-
-		// slice type명과 struct type명이 같다면 slice type명에 접미사로 'List'를 붙임
-		code += "\t" + `if sliceTypeName == structName {` + "\n"
-		code += "\t\t" + `sliceTypeName += "List"` + "\n"
-		code += "\t" + `}` + "\n"
+		// sliceTypeName은 generate-time에 확정되어 파라미터로 전달된다
+		// (naming.FixInitialismPlural 적용 완료).
 
 		// named type 추가
 		code += "\t" + `code += "type " + sliceTypeName + " []" + structName + "\n\n"` + "\n"


### PR DESCRIPTION
## 요약

`SLICE` feature의 slice 타입명 생성 시, 끝이 대문자 약어인 struct에 대문자 `S`가 붙던 문제(#23)를 수정합니다.

- `ProductURL` → `type ProductURLs []ProductURL` (기존: `ProductURLS`)
- `UserID` → `UserIDs` (기존: `UserIDS`)

## 변경 내용

- `internal/naming` 패키지 추가: golint `commonInitialisms` 기반 `FixInitialismPlural`. 끝이 `<약어>S` 인 경우에만 마지막 `S` 를 소문자화하며, 일반 복수형(`Orders`)이나 비약어(`CMS`)는 그대로 둡니다.
- slice 타입명을 러너 런타임이 아니라 **generate-time** 에 확정하도록 변경(`internal/steps/generate_runner.go`). `structName` 의 순수 함수라 결과는 동일하고, 이 지점에서 `FixInitialismPlural` 을 적용해 러너에는 최종 문자열만 리터럴로 전달합니다.
- 유닛 테스트 추가(`internal/naming/naming_test.go`).

## 확인

- 기존 동작 유지: `Order` → `Orders`, `Person` → `People`, `Clothes` → `ClothesList`.
- `go build/vet/test ./...` 통과, example 전체/선택 재생성으로 결과 확인.

Closes #23
