### PR TITLE
[#24] 특정 파일만 선택해 생성하는 옵션 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,13 @@ gormery
 
 gormery only generates structures with `// @Gorm` comments. t reads structures and fields and produces a list of methods and constants.
 
+By default, every file under `basedir` is processed. To generate only for specific files, pass them as arguments:
+
+```
+gormery                            # process everything under basedir
+gormery example/clothes.go a.go    # process only the given files
+```
+
 If you have a struct like
 
 ```

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,10 +8,17 @@ import (
 )
 
 var rootCmd = &cobra.Command{
-	Use:   "gormery",
+	Use:   "gormery [files...]",
 	Short: "generate gormery codes",
+	Long: "generate gormery codes\n\n" +
+		"With no arguments, every file under basedir is processed.\n" +
+		"Pass one or more file paths to generate only for those files, e.g.:\n" +
+		"  gormery example/clothes.go example/order.go",
+	// Accept positional file paths; without this cobra's legacyArgs rejects
+	// them as unknown subcommands because a "version" subcommand is registered.
+	Args: cobra.ArbitraryArgs,
 	Run: func(cmd *cobra.Command, args []string) {
-		run.RunGenerate()
+		run.RunGenerate(args)
 	},
 }
 

--- a/internal/run/generate.go
+++ b/internal/run/generate.go
@@ -6,12 +6,14 @@ import (
 	steps "github.com/myyrakle/gormery/internal/steps"
 )
 
-func RunGenerate() {
+// RunGenerate generates gormery code. When selected is non-empty, only the
+// given source files are processed; otherwise the whole basedir is scanned.
+func RunGenerate(selected []string) {
 	fmt.Println(">>> Running LoadConfigFile")
 	configFile := steps.LoadConfigFile()
 
 	fmt.Println(">>> Running ReadAllTargets")
-	targets := steps.ReadAllTargets(configFile)
+	targets := steps.ReadAllTargets(configFile, selected)
 
 	fmt.Println(">>> Running GenerateRunner")
 	steps.GenerateRunner(configFile, targets)

--- a/internal/steps/read_all_targets.go
+++ b/internal/steps/read_all_targets.go
@@ -17,10 +17,44 @@ import (
 	slice "github.com/myyrakle/gormery/pkg/slice"
 )
 
-func ReadAllTargets(configFile config.ConfigFile) ProecssFileContexts {
+func ReadAllTargets(configFile config.ConfigFile, selected []string) ProecssFileContexts {
 	contexts := readFileRecursive(configFile.Basedir, configFile)
 
+	if len(selected) > 0 {
+		contexts = filterBySelectedFiles(contexts, selected)
+	}
+
 	return contexts
+}
+
+// filterBySelectedFiles keeps only the contexts whose source file matches one of
+// the selected paths. Matching is forgiving: both a cleaned full-path match and a
+// base-name match count, so "example/clothes.go", "./example/clothes.go" and
+// "clothes.go" all select example/clothes.go. Paths are normalized to forward
+// slashes to stay consistent with the Windows handling in readFileRecursive.
+func filterBySelectedFiles(contexts ProecssFileContexts, selected []string) ProecssFileContexts {
+	wanted := make(map[string]bool, len(selected))
+	wantedBase := make(map[string]bool, len(selected))
+	for _, s := range selected {
+		s = strings.ReplaceAll(s, "\\", "/")
+		clean := path.Clean(s)
+		wanted[clean] = true
+		wantedBase[path.Base(clean)] = true
+	}
+
+	filtered := make(ProecssFileContexts, 0, len(contexts))
+	for _, context := range contexts {
+		clean := path.Clean(context.filename)
+		if wanted[clean] || wantedBase[path.Base(clean)] {
+			filtered = append(filtered, context)
+		}
+	}
+
+	if len(filtered) == 0 {
+		log.Printf("gormery: no @Gorm targets matched the selected files: %v", selected)
+	}
+
+	return filtered
 }
 
 type ProcessFileField struct {


### PR DESCRIPTION
## 요약

`basedir` 전체가 아니라 지정한 파일만 생성하는 옵션(#24)을 추가합니다.

```
gormery                            # 기존: basedir 전체
gormery example/clothes.go a.go    # 선택한 파일만
```

## 변경 내용

- `cmd/root.go`: 위치 인자를 `RunGenerate` 로 전달. `version` 서브커맨드가 등록돼 있어 cobra `legacyArgs` 가 위치 인자를 미지의 커맨드로 거부하므로 `Args: cobra.ArbitraryArgs` 를 설정했습니다. 사용법 도움말도 추가.
- `internal/run/generate.go`: `RunGenerate(selected []string)`.
- `internal/steps/read_all_targets.go`: `ReadAllTargets(configFile, selected)` — 선택 인자가 있으면 `filterBySelectedFiles` 로 필터링. 전체 경로/파일명(basename) 매칭, forward-slash 정규화(윈도우 처리와 일관). 매칭 0건이면 경고 로그.
- `README.md`: 선택 실행 사용법 보강.

## 동작

- 인자가 없으면 기존과 100% 동일 (하위호환).
- 스캔은 패키지 파싱을 위해 전체를 읽되 **생성 대상만** 필터링합니다. 선택한 `_gorm.go` 만 재생성되고 나머지는 그대로 유지됩니다.

Closes #24
